### PR TITLE
Added setup_keys.sh to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # DowntimeMonitoring
+
 ## Build
 Run the `./setup_keys.sh` script  
-
 Build using docker: `docker compose build`
+
 ## Run
-Run using the `start.sh` script
+Run using the `./start.sh` script
+
 ## Usage
 This solution has 3 main pages:
 - Data capture - [http://localhost](http://localhost) on the device (i.e. Raspberry Pi) or http://\<ip\> from other devices on the local network (where \<ip\> is the devices fixed IP address) (e.g. http://192.168.0.1 for IP address 192.168.0.1)
+
 - Admin page - [http://localhost:8001/admin](http://localhost:8001/admin) on the device or http://\<ip\>:8001/admin from other devices (username: admin, password: admin) [Please change password from default]
+ 
 - Dashboard - [http://localhost:3000](http://localhost:3000) on the device or http://\<ip\>:3000 from other devices (username: admin, password: admin) [Please change password from default]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DowntimeMonitoring
 ## Build
+Run the `./setup_keys.sh` script  
+
 Build using docker: `docker compose build`
 ## Run
 Run using the `start.sh` script


### PR DESCRIPTION
Added a line about setup_keys.sh to README.md.

Not sure why this wasn't in #6 , the `setup_keys` script has always been here [since the begining](https://github.com/DigitalShoestringSolutions/DowntimeMonitoring/blob/f7b99ca2d0cd42cde5e41ea7029230e755f9f8de/setup_keys.sh).

I wondered briefly if therefore the `setup_keys` step was optional (like `docker compose build` is, `./start.sh` will cover it for you if you forget).
Tried to builld the solution ignoring this step, results in error:
```
env file /home/pi/DowntimeMonitoring/django_secret_key not found: stat /home/pi/DowntimeMonitoring/django_secret_key: no such file or directory
```
Hence it must be done, so it would be sporting to give a hint to users. 