### PR TITLE
Consistent tables in Capture UI

### DIFF
--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -158,7 +158,7 @@ function EventLog({ events, config, current, handleEventClick }) {
     <Table bordered striped responsive="sm">
       <thead>
         <tr>
-          <th>Time</th>
+          <th>Downtime</th>
           <th>Duration</th>
           <th>Reason</th>
         </tr>
@@ -166,7 +166,7 @@ function EventLog({ events, config, current, handleEventClick }) {
       <tbody>
         {current_page_set.map((event, index) => (
           <tr key={index}>
-            <td>{dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
+            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} + "to" + {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
             <td>{event.duration ? dayjs.duration(event.duration).format('m[m] s[s]') : ""}</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -167,7 +167,7 @@ function EventLog({ events, config, current, handleEventClick }) {
         {current_page_set.map((event, index) => (
           <tr key={index}>
             <td>{dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')}</td>
-            <td>{event.duration ? dayjs.duration(event.duration).format('m[m ]') dayjs.duration(event.duration).seconds()}s</td>
+            <td>{event.duration ? dayjs.duration(event.duration).minutes() : ""}m {Math.round(dayjs.duration(event.duration).seconds())}s</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>
         ))}

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -167,7 +167,7 @@ function EventLog({ events, config, current, handleEventClick }) {
         {current_page_set.map((event, index) => (
           <tr key={index}>
             <td>{dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')}</td>
-            <td>{event.duration ? dayjs.duration(event.duration).format('m[m] Math.round(s)[s]') : ""}</td>
+            <td>{event.duration ? dayjs.duration(event.duration).format('m[m ]') dayjs.duration(event.duration).seconds()}s</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>
         ))}

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -167,7 +167,7 @@ function EventLog({ events, config, current, handleEventClick }) {
         {current_page_set.map((event, index) => (
           <tr key={index}>
             <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
-            <td>{event.duration ? dayjs.duration(event.duration).format('m[m] s[s]') : ""}</td>
+            <td>{event.duration ? dayjs.duration(event.duration).format('m[m] Math.round(s)[s]') : ""}</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>
         ))}

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -167,7 +167,7 @@ function EventLog({ events, config, current, handleEventClick }) {
         {current_page_set.map((event, index) => (
           <tr key={index}>
             <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
-            <td>{event.stop ? dayjs.duration(dayjs(event.stop).diff(dayjs(event.start))).format('m[m] s[s]') : ""}</td>
+            <td>{event.duration ? dayjs.duration(event.duration).format('m[m] s[s]') : ""}</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>
         ))}

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -166,7 +166,7 @@ function EventLog({ events, config, current, handleEventClick }) {
       <tbody>
         {current_page_set.map((event, index) => (
           <tr key={index}>
-            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
+            <td>{dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')}</td>
             <td>{event.duration ? dayjs.duration(event.duration).format('m[m] Math.round(s)[s]') : ""}</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -166,7 +166,7 @@ function EventLog({ events, config, current, handleEventClick }) {
       <tbody>
         {current_page_set.map((event, index) => (
           <tr key={index}>
-            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} + "to" + {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
+            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
             <td>{event.duration ? dayjs.duration(event.duration).format('m[m] s[s]') : ""}</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>

--- a/stoppage_dc/code/src/AutoCapturePage.jsx
+++ b/stoppage_dc/code/src/AutoCapturePage.jsx
@@ -167,7 +167,7 @@ function EventLog({ events, config, current, handleEventClick }) {
         {current_page_set.map((event, index) => (
           <tr key={index}>
             <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
-            <td>{event.duration ? dayjs.duration(event.duration).format('m[m] s[s]') : ""}</td>
+            <td>{event.stop ? dayjs.duration(dayjs(event.stop).diff(dayjs(event.start))).format('m[m] s[s]') : ""}</td>
             <td>{event.reason ? event.reason : <Button onClick={() => handleEventClick(event)}>Set</Button>}</td>
           </tr>
         ))}

--- a/stoppage_dc/code/src/ManualCapturePage.jsx
+++ b/stoppage_dc/code/src/ManualCapturePage.jsx
@@ -149,7 +149,7 @@ function EventLog({ events, config, current }) {
       <tbody>
         {current_page_set.map((event, index) => (
           <tr key={index}>
-            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} + "to" + {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
+            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
             <td>{event.stop ? dayjs.duration(dayjs(event.stop).diff(dayjs(event.start))).format('m[m] s[s]') : ""}</td>
             <td>{event.reason}</td>
           </tr>

--- a/stoppage_dc/code/src/ManualCapturePage.jsx
+++ b/stoppage_dc/code/src/ManualCapturePage.jsx
@@ -149,7 +149,7 @@ function EventLog({ events, config, current }) {
       <tbody>
         {current_page_set.map((event, index) => (
           <tr key={index}>
-            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
+            <td>{dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')} to {dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')}</td>
             <td>{event.stop ? dayjs.duration(dayjs(event.stop).diff(dayjs(event.start))).format('m[m] s[s]') : ""}</td>
             <td>{event.reason}</td>
           </tr>

--- a/stoppage_dc/code/src/ManualCapturePage.jsx
+++ b/stoppage_dc/code/src/ManualCapturePage.jsx
@@ -141,17 +141,17 @@ function EventLog({ events, config, current }) {
     <Table bordered striped responsive="sm">
       <thead>
         <tr>
-          <th>Reason</th>
-          <th>Time</th>
+          <th>Downtime</th>
           <th>Duration</th>
+          <th>Reason</th>
         </tr>
       </thead>
       <tbody>
         {current_page_set.map((event, index) => (
           <tr key={index}>
-            <td>{event.reason}</td>
-            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')}</td>
+            <td>{dayjs(event.start).format('DD/MM/YYYY HH:mm:ss')} + "to" + {dayjs(event.stop).format('DD/MM/YYYY HH:mm:ss')}</td>
             <td>{event.stop ? dayjs.duration(dayjs(event.stop).diff(dayjs(event.start))).format('m[m] s[s]') : ""}</td>
+            <td>{event.reason}</td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
Aims to fix #16 and #17

Makes the tables in the reason capture pages more alike. Puts the columns in the same order, display the timestamps more consistently.
